### PR TITLE
基本情報登録機能

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,28 @@
+class CategoriesController < ApplicationController
+  before_action :authenticate_user!, except: [:index]
+  def index
+    @categories = Category.all
+  end
+
+  def new
+    @categories = Category.new
+  end
+
+  def create
+    @categories = Category.create(category_params)
+    if @categories.all?(&:valid?)
+      redirect_to categories_path, notice: 'Categories were successfully created.'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def category_params
+    params.require(:categories).map do |p|
+      p.permit(:category_name)
+    end
+  end
+
+end

--- a/app/controllers/company_infos_controller.rb
+++ b/app/controllers/company_infos_controller.rb
@@ -1,0 +1,59 @@
+class CompanyInfosController < ApplicationController
+  before_action :authenticate_user!, except: [:index]
+  before_action :set_company_info, only: [:new, :create]
+
+  def index
+    @company_infos = CompanyInfo.all
+  end
+  
+  def new
+    @company_info ||= CompanyInfo.new
+  end
+
+  def create
+    if @company_info.nil?
+      @company_info = CompanyInfo.new(company_params)
+      if @company_info.save
+        redirect_to company_infos_path, notice: 'Company information was successfully created.'
+      else
+        render :new
+      end
+    else
+      if @company_info.update(company_params)
+        redirect_to company_infos_path, notice: 'Company information was successfully updated.'
+      else
+        render :new
+      end
+    end
+  end
+  
+  
+  def edit
+    @company_info = CompanyInfo.find(params[:id])
+  end
+
+  def update
+    @company_info = CompanyInfo.find(params[:id]) 
+    if @company_info.update(company_params)
+      flash[:success] = '会社情報が正常に更新されました。'
+      redirect_to @company_info
+    else
+      render :edit
+    end
+  end
+  
+
+  def show
+    @company_info = CompanyInfo.find(params[:id])
+  end
+  
+  private
+
+  def set_company_info
+    @company_info = CompanyInfo.first || CompanyInfo.new
+  end  
+
+  def company_params
+    params.require(:company_info).permit(:company_name, :postcode, :address, :phone_number, :fax_number)
+  end
+end

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -1,4 +1,7 @@
 class EstimatesController < ApplicationController
   def index
   end
+
+  def data_registration
+  end
 end

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -1,0 +1,27 @@
+class UnitsController < ApplicationController
+  before_action :authenticate_user!, except: [:index]
+  def index
+    @units = Unit.all
+  end
+
+  def new
+    @units = Unit.new
+  end
+
+  def create
+    @units = Unit.create(unit_params)
+    if @units.all?(&:valid?)
+      redirect_to units_path, notice: 'units were successfully created.'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def unit_params
+    params.require(:units).map do |p|
+      p.permit(:unit_name)
+    end
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,5 @@
+class Category < ApplicationRecord
+  has_many :sales_quotation_items
+
+  validates :category_name, uniqueness: { case_sensitive: true }
+end

--- a/app/models/company_info.rb
+++ b/app/models/company_info.rb
@@ -1,0 +1,2 @@
+class CompanyInfo < ApplicationRecord
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,0 +1,5 @@
+class Unit < ApplicationRecord
+  has_many :sales_quotation_items
+  
+  validates :unit_name, uniqueness: { case_sensitive: true }
+end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,31 @@
+<%= render "shared/header"%>
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+<h3>Category</h3>
+
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-7"> <!-- col-md-7 gives the table 60% of the width -->
+      <div class="table-responsive">
+        <table class="table table-bordered table-striped">
+          <thead class="thead-light">
+            <tr>
+              <th scope="col">ID</th>
+              <th scope="col">カテゴリー</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @categories.each.with_index(1) do |category, index| %>
+              <tr>
+                <td><%= index %></td>
+                <td><%= category.category_name %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <div class="text-center">
+        <%= link_to '新規登録', new_category_path, class: 'btn btn-primary' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,25 @@
+<%= render "shared/header"%>
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+
+      <%= form_with url: categories_path, method: :post, local: true do |form| %>
+        <div id="categories">
+          <%= form.fields_for 'categories[]', Category.new do |category_form| %>
+            <div class="form-group">
+              <%= category_form.label :category_name, "カテゴリー名" %>
+              <%= category_form.text_field :category_name, class: "form-control" %>
+            </div>
+          <% end %>
+        </div>
+
+        <div class="text-center mt-4">
+          <%= form.submit "登録", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+
+    </div>
+  </div>
+</div>

--- a/app/views/company_infos/edit.html.erb
+++ b/app/views/company_infos/edit.html.erb
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>会社情報編集</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+</head>
+<body>
+  <%= render "shared/header" %>
+  <div class="container">
+    <h3>会社情報編集</h3>
+
+    <%= form_with model: @company_info, local: true do |form| %>
+      <div class="form-group">
+        <%= form.label :company_name, "会社名" %>
+        <%= form.text_field :company_name, class: "form-control", placeholder: "Company name" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :postcode, "郵便番号" %>
+        <%= form.text_field :postcode, class: "form-control", placeholder: "Postcode" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :address, "住所" %>
+        <%= form.text_field :address, class: "form-control", placeholder: "Address" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :phone_number, "電話番号" %>
+        <%= form.text_field :phone_number, class: "form-control", placeholder: "Phone number" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :fax_number, "FAX番号" %>
+        <%= form.text_field :fax_number, class: "form-control", placeholder: "Fax number" %>
+      </div>
+      <div class="d-flex justify-content-center">
+        <%= form.submit "更新", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</body>
+</html>

--- a/app/views/company_infos/index.html.erb
+++ b/app/views/company_infos/index.html.erb
@@ -1,0 +1,44 @@
+<%= render "shared/header" %>
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+<h3>登録情報</h3>
+
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-7">
+      <div class="table-responsive">
+        <% @company_infos.each do |info| %>
+          <table class="table table-bordered table-striped">
+            <tbody>
+              <tr>
+                <th>会社名</th>
+                <td><%= info.company_name %></td>
+              </tr>
+              <tr>
+                <th>郵便番号</th>
+                <td><%= info.postcode %></td>
+              </tr>
+              <tr>
+                <th>住所</th>
+                <td><%= info.address %></td>
+              </tr>
+              <tr>
+                <th>電話番号</th>
+                <td><%= info.phone_number %></td>
+              </tr>
+              <tr>
+                <th>FAX番号</th>
+                <td><%= info.fax_number %></td>
+              </tr>
+            </tbody>
+          </table>
+          <%= link_to '編集', edit_company_info_path(info), class: 'btn btn-secondary mb-3' %> <!-- 編集ボタン -->
+        <% end %>
+        <% unless @company_infos.count > 0 %> <!-- データが登録されていない場合のみ新規登録ボタンを表示 -->
+          <div class="text-center">
+            <%= link_to '新規登録', new_company_info_path, class: 'btn btn-primary' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/company_infos/new.html.erb
+++ b/app/views/company_infos/new.html.erb
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+  <title>会社情報登録</title>
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+</head>
+<%= render "shared/header"%>
+<body>
+  <div class="container">
+    <h3>会社情報登録</h3>
+    <% if @company_info.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(@company_info.errors.count, "error") %> prohibited this company from being saved:</h2>
+
+        <ul>
+          <% @company_info.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <%= form_with model: @company_info, local: true do |form| %>
+      <div class="form-group">
+        <%= form.label :company_name, "会社名" %>
+        <%= form.text_field :company_name, class: "form-control", placeholder: "Company name" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :postcode, "郵便番号" %>
+        <%= form.text_field :postcode, class: "form-control", placeholder: "Postal code" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :address, "住所" %>
+        <%= form.text_field :address, class: "form-control", placeholder: "Address" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :phone_number, "電話番号" %>
+        <%= form.text_field :phone_number, class: "form-control", placeholder: "Phone number" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :fax_number, "FAX番号" %>
+        <%= form.text_field :fax_number, class: "form-control", placeholder: "Fax number" %>
+      </div>
+
+      <div class="d-flex justify-content-center">
+        <%= form.submit "登録", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</body>
+</html>

--- a/app/views/company_infos/show.html.erb
+++ b/app/views/company_infos/show.html.erb
@@ -1,0 +1,37 @@
+<%= render "shared/header" %>
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+
+<h3>会社詳細情報</h3>
+
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-7">
+      <table class="table table-bordered table-striped">
+        <tbody>
+          <tr>
+            <th>会社名</th>
+            <td><%= @company_info.company_name %></td>
+          </tr>
+          <tr>
+            <th>郵便番号</th>
+            <td><%= @company_info.postcode %></td>
+          </tr>
+          <tr>
+            <th>住所</th>
+            <td><%= @company_info.address %></td>
+          </tr>
+          <tr>
+            <th>電話番号</th>
+            <td><%= @company_info.phone_number %></td>
+          </tr>
+          <tr>
+            <th>FAX番号</th>
+            <td><%= @company_info.fax_number %></td>
+          </tr>
+        </tbody>
+      </table>
+      <%= link_to '編集', edit_company_info_path(@company_info), class: 'btn btn-secondary mb-3' %> <!-- 編集ボタン -->
+      <%= link_to '戻る', company_infos_path, class: 'btn btn-light mb-3' %> <!-- 戻るボタン -->
+    </div>
+  </div>
+</div>

--- a/app/views/estimates/data_registration.html.erb
+++ b/app/views/estimates/data_registration.html.erb
@@ -25,7 +25,7 @@
               <% end %>
             </div>
             <div class="col-sm">
-              <%= link_to("#", class: 'btn btn-secondary btn-lg btn-block') do %>
+              <%= link_to(units_path, class: 'btn btn-secondary btn-lg btn-block') do %>
                 <i class="fas fa-ruler"></i> 単位登録
               <% end %>
             </div>

--- a/app/views/estimates/data_registration.html.erb
+++ b/app/views/estimates/data_registration.html.erb
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+<%= render "shared/header"%>
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Registration</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="full-height d-flex flex-column justify-content-around">
+    <div class="container">
+        <div class="row button-row">
+            <div class="col-sm">
+              <%= link_to(company_infos_path, class: 'btn btn-warning btn-lg btn-block') do %>
+                <i class="fas fa-building"></i> 会社情報登録
+              <% end %>
+            </div>
+            <div class="col-sm">
+              <%= link_to(categories_path, class: 'btn btn-primary btn-lg btn-block') do %>
+                <i class="fas fa-tags"></i> カテゴリ登録
+              <% end %>
+            </div>
+            <div class="col-sm">
+              <%= link_to("#", class: 'btn btn-secondary btn-lg btn-block') do %>
+                <i class="fas fa-ruler"></i> 単位登録
+              <% end %>
+            </div>
+        </div>
+    </div>
+  </div>
+</body>
+</html>
+

--- a/app/views/estimates/index.html.erb
+++ b/app/views/estimates/index.html.erb
@@ -40,7 +40,7 @@
         </div>
         <div class="row button-row">
             <div class="col-sm">
-              <%= link_to("#", class: 'btn btn-success btn-lg btn-block') do %>
+              <%= link_to(data_registration_estimates_path, class: 'btn btn-success btn-lg btn-block') do %>
                 <i class="fas fa-database"></i> データ登録
               <% end %>
             </div>

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -1,0 +1,31 @@
+<%= render "shared/header"%>
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+<h3>単位一覧</h3>
+
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-7"> <!-- col-md-7 gives the table 60% of the width -->
+      <div class="table-responsive">
+        <table class="table table-bordered table-striped">
+          <thead class="thead-light">
+            <tr>
+              <th scope="col">ID</th>
+              <th scope="col">カテゴリー</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @units.each.with_index(1) do |unit, index| %>
+              <tr>
+                <td><%= index %></td>
+                <td><%= unit.unit_name %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <div class="text-center">
+        <%= link_to '新規登録', new_unit_path, class: 'btn btn-primary' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/units/new.html.erb
+++ b/app/views/units/new.html.erb
@@ -1,0 +1,26 @@
+<%= render "shared/header" %>
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <h3 class="mb-4 text-center">単位登録</h3>
+
+      <%= form_with url: units_path, method: :post, local: true do |form| %>
+        <div id="units">
+          <%= form.fields_for 'units[]', Unit.new do |unit_form| %>
+            <div class="form-group">
+              <%= unit_form.label :unit_name, "単位" %>
+              <%= unit_form.text_field :unit_name, class: "form-control", placeholder: "単位を入力してください" %>
+            </div>
+          <% end %>
+        </div>
+        <script src="js/sales_quotation.js"></script>
+
+        <div class="text-center mt-4">
+          <%= form.submit "登録", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,6 @@ Rails.application.routes.draw do
   resources :company_infos, only: [:new, :create, :index, :show, :edit, :update]
 
   resources :categories, only: [:new, :create, :index]
+
+  resources :units, only: [:new, :create, :index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,13 @@ Rails.application.routes.draw do
   root to: "estimates#index"
   devise_for :users
 
-  resources :estimates, only: [:index]
+  resources :estimates, only: [:index] do
+    collection do
+      get :data_registration
+    end
+  end
+
+  resources :company_infos, only: [:new, :create, :index, :show, :edit, :update]
+
+  resources :categories, only: [:new, :create, :index]
 end

--- a/db/migrate/20230815213945_create_company_infos.rb
+++ b/db/migrate/20230815213945_create_company_infos.rb
@@ -1,0 +1,12 @@
+class CreateCompanyInfos < ActiveRecord::Migration[6.0]
+  def change
+    create_table :company_infos do |t|
+      t.string :company_name, null: false
+      t.string :postcode,   null: false
+      t.string :address, null: false
+      t.string :phone_number, null: false
+      t.string :fax_number, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230815215837_create_categories.rb
+++ b/db/migrate/20230815215837_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :categories do |t|
+      t.string :category_name, null: false
+      t.timestamps
+    end
+    add_index :categories, :category_name, unique: true
+  end
+end

--- a/db/migrate/20230815221237_create_units.rb
+++ b/db/migrate/20230815221237_create_units.rb
@@ -1,0 +1,9 @@
+class CreateUnits < ActiveRecord::Migration[6.0]
+  def change
+    create_table :units do |t|
+      t.string :unit_name, null: false
+      t.timestamps
+    end
+    add_index :units, :unit_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_15_215837) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_15_221237) do
   create_table "categories", charset: "utf8", force: :cascade do |t|
     t.string "category_name", null: false
     t.datetime "created_at", null: false
@@ -26,6 +26,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_15_215837) do
     t.string "fax_number", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "units", charset: "utf8", force: :cascade do |t|
+    t.string "unit_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["unit_name"], name: "index_units_on_unit_name", unique: true
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_15_180514) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_15_215837) do
+  create_table "categories", charset: "utf8", force: :cascade do |t|
+    t.string "category_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_name"], name: "index_categories_on_category_name", unique: true
+  end
+
+  create_table "company_infos", charset: "utf8", force: :cascade do |t|
+    t.string "company_name", null: false
+    t.string "postcode", null: false
+    t.string "address", null: false
+    t.string "phone_number", null: false
+    t.string "fax_number", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "last_name", default: "", null: false
     t.string "first_name", default: "", null: false


### PR DESCRIPTION
# What

基本情報登録機能の実装。
- 自社情報の登録：システムには自社情報を1件のみ登録可能。後から編集や更新ができる。
- カテゴリー：見積もりを行う際の分類を設定できる。これにより、特定のカテゴリごとに見積もりを行うことが可能になる。
- 単位：見積もりを作成する際に使用する単位（例：個、kg、m2など）を自由に設定・登録できる。これにより、多様な商品やサービスの見積もりを柔軟に作成できる。

# Why

自社情報の登録：自社情報はビジネスの基盤となる情報であり、見積もりに表示される。1件のみの登録を許容することで、誤った情報の登録や重複を防ぐ。

カテゴリー：商品やサービスは多種多様であり、それらを適切に分類することは、見積もりの整理や分析に不可欠である。

単位：各商品やサービスには適切な単位が存在する。例えば、液体は「ml」や「L」、売り地は「m2」、一般的な商品は「個」として数える。この単位をカスタマイズ可能にすることで、より正確で専門的な見積もりを提供できる。