### PR TITLE
販売再見積機能

### DIFF
--- a/app/assets/stylesheets/pdf.css
+++ b/app/assets/stylesheets/pdf.css
@@ -80,10 +80,6 @@ td:nth-child(7) /* 備考の値 */
     width: 20% !important; 
 }
 
-.download-button {
-  display: none !important;
-}
-
 /* BootstrapのGridシステムの模倣 */
 .pdf-container-fluid {
   width: 100% !important;
@@ -150,3 +146,5 @@ td:nth-child(7) /* 備考の値 */
 .font-weight-bold {
   font-weight: bold !important;
 }
+
+

--- a/app/assets/stylesheets/sales_quotation/new.css
+++ b/app/assets/stylesheets/sales_quotation/new.css
@@ -1,6 +1,7 @@
-.nested-fields {
+.sales_quotations.new .nested-fields {
   display: none;
 }
+
 
 /* ベーススタイル */
 .container {

--- a/app/assets/stylesheets/sales_quotation/show.css
+++ b/app/assets/stylesheets/sales_quotation/show.css
@@ -89,4 +89,7 @@ td:nth-child(7) /* 備考の値 */
   .download-button {
     display: none;
   }
+  .requote-button {
+    display: none;
+  }
 }

--- a/app/javascript/sales_quotation.js
+++ b/app/javascript/sales_quotation.js
@@ -1,24 +1,38 @@
 document.addEventListener("DOMContentLoaded", function() {
   const addRowsButton = document.getElementById('addRows');
-  let currentRowCount = 1; // 表示されている行数
-  const maxRowsToShowAtOnce = 1; // 一度に表示する行数
+  let currentRowCount = 0;
+  const maxRowsToShowAtOnce = 1;
 
-  addRowsButton.addEventListener('click', function() {
-    console.log('ボタンがクリックされました'); // クリックが発生したことを確認するためのログ
+  const allRows = document.querySelectorAll('.nested-fields');
 
-    const allRows = document.querySelectorAll('.nested-fields');
-    for (let i = currentRowCount; i < currentRowCount + maxRowsToShowAtOnce && i < allRows.length; i++) {
-      allRows[i].style.display = 'table-row';
-      console.log('行を表示しました:', i); // 行を表示したことを確認するためのログ
-    }
-    currentRowCount += maxRowsToShowAtOnce;
-    
-    // すべての行が表示されている場合、+マークのボタンを隠す
-    if (currentRowCount >= allRows.length) {
-      addRowsButton.style.display = 'none';
-      console.log('すべての行が表示されました'); // すべての行が表示されたことを確認するためのログ
+  // 初期ロード時に必須項目が1つ以上入力されている行だけを表示
+  allRows.forEach(row => {
+    const fields = Array.from(row.querySelectorAll('.form-control')).filter(el => el.className !== 'form-control note');  // note クラスを持つ要素は除外
+
+    const hasInput = fields.some(field => {
+      return field.value.trim() !== "";
+    });
+
+    if (hasInput) {
+      row.style.display = 'table-row';
+      currentRowCount++; // 表示されている行数を増やす
+    } else {
+      row.style.display = 'none'; // 必須項目がすべて空の場合は非表示
     }
   });
 
-  addRowsButton.click();
+  addRowsButton.addEventListener('click', function() {
+    console.log('ボタンがクリックされました');
+
+    for (let i = currentRowCount; i < currentRowCount + maxRowsToShowAtOnce && i < allRows.length; i++) {
+      allRows[i].style.display = 'table-row';
+      console.log('行を表示しました:', i + 1);
+    }
+    currentRowCount += maxRowsToShowAtOnce;
+
+    if (currentRowCount >= allRows.length) {
+      addRowsButton.style.display = 'none';
+      console.log('すべての行が表示されました');
+    }
+  });
 });

--- a/app/views/sales_quotations/_sales_quotation_item_fields.html.erb
+++ b/app/views/sales_quotations/_sales_quotation_item_fields.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-bordered">
+
 <tr class="nested-fields" data-controller="amount">
     <td class="col-2">
       <%= f.select :category_id, [['', '']] + Category.all.map { |c| [c.category_name, c.id] }, {}, class: "form-control" %>
@@ -17,4 +17,3 @@
     <td class="col-2"><%= content_tag :span, "", class: "amount" %></td>
     <td class="col-2"><%= f.text_field :note, class: "form-control" %></td>
   </tr>
-</table>

--- a/app/views/sales_quotations/edit.html.erb
+++ b/app/views/sales_quotations/edit.html.erb
@@ -21,17 +21,10 @@
         <div class="form-group">
           <%= form.label :quotation_number, "見積番号" %>
           <%= form.text_field :quotation_number, class: "form-control", disabled: true %>
-
-          <div data-controller="sales_quotation">
-            <%= form.label :customer_id, "顧客名" %>
-            <%= form.select :customer_id, options_for_select(@customers), { include_blank: '選択してください' }, class: "form-control", data: { action: "change->sales-quotation#fetchRepresentatives" } %>
-            
-            <%= form.label :representative_id, "部署名 - 担当者名" %>
-            <%= turbo_frame_tag "representative_options" do %>
-              <%= form.select :representative_id, options_for_select(@representatives), { include_blank: '-' }, class: "form-control", data: { target: "sales-quotation.representativeSelect" } %>
-            <% end %>
-          </div>
-
+          <%= form.label :customer_id, "顧客名" %>
+          <%= form.collection_select :customer_id, Customer.all, :id, :customer_name, { include_blank: '選択してください' }, class: "form-control", selected: @sales_quotation.customer_id %>
+          <%= form.label :representative_id, "部署名 - 担当者名" %>
+          <%= form.select :representative_id, options_for_select(@representatives, @sales_quotation.representative_id), { include_blank: '-' }, class: "form-control", data: { target: "sales-quotation.representativeSelect" } %>
           <%= form.label :delivery_place, "納入場所" %>
           <%= form.text_field :delivery_place, class: "form-control" %>
           <%= form.label :request_date, "見積依頼日" %>
@@ -46,7 +39,7 @@
           <%= form.text_field :trading_conditions, class: "form-control" %>
         </div>
 
-        <table class="table table-bordered mt-4">
+        <table class="table table-bordered mt-4" data-action-type="edit">
           <thead>
             <tr>
               <th class="col-2">カテゴリ</th>
@@ -59,8 +52,10 @@
             </tr>
           </thead>
           <tbody>
-            <%= form.fields_for :sales_quotation_items do |item_fields| %>
-              <%= render 'sales_quotation_item_fields', f: item_fields %>
+            <% @sales_quotation_items.each do |item| %>
+              <%= form.fields_for :sales_quotation_items, item do |item_fields| %>
+                <%= render 'sales_quotation_item_fields', f: item_fields %>
+              <% end %>
             <% end %>
           </tbody>
         </table>
@@ -69,10 +64,15 @@
           <i class="fas fa-plus"></i> 行を追加
         </button>
 
+
         <div class="d-flex justify-content-center mt-4">
           <%= form.submit "作成", class: "btn btn-primary" %>
         </div>
-      <% end %>
+
+      <% end %> 
     </div>
-     <%= javascript_include_tag 'sales_quotation' %>
   </div>
+
+  <%= javascript_include_tag 'sales_quotation' %>
+
+</div>

--- a/app/views/sales_quotations/show.html.erb
+++ b/app/views/sales_quotations/show.html.erb
@@ -1,4 +1,7 @@
-<%= link_to 'PDFでダウンロード', sales_quotation_path(@sales_quotation, format: :pdf), class: 'btn btn-primary download-button' %>
+<div class="btn-group" role="group" aria-label="ボタングループ">
+    <%= link_to 'PDFでダウンロード', sales_quotation_path(@sales_quotation, format: :pdf), class: 'btn btn-primary download-button' %>
+    <%= link_to '再見積', edit_sales_quotation_path(@sales_quotation), class: 'btn btn-success requote-button' %>
+</div>
 
 <div class="pdf-quotation-wrapper">
 <div class="text-center">

--- a/app/views/sales_quotations/show.pdf.erb
+++ b/app/views/sales_quotations/show.pdf.erb
@@ -1,9 +1,10 @@
-<div class="pdf-text-center">
+<div class="pdf-quotation-wrapper">
+<div class="text-center">
     <h1>販売見積書</h1>
 </div>
-<div class="pdf-container-fluid">
-    <div class="pdf-row mb-5 p-3 rounded">
-        <div class="pdf-col-md-6">
+<div class="container-fluid">
+    <div class="row mb-5 p-3 rounded">
+        <div class="col-md-6">
             <% representative = @sales_quotation.representative %>
             <h2>
                 <%= @customer.customer_name %>
@@ -19,20 +20,20 @@
                 <% end %>
             </h4>
         </div>
-        <div class="pdf-col-md-6 pdf-text-right">
+        <div class="col-md-6 text-right">
             <p>見 積 日: <%= @sales_quotation.quotation_date.strftime("%Y年%m月%d日") %></p>
             <p>見積番号: <%= @sales_quotation.quotation_number %></p>
         </div>
     </div>
-    <div class="pdf-row mb-4">
-        <div class="pdf-col-md-6">
+    <div class="row mb-4">
+        <div class="col-md-6">
             <p>有効期限: <%= @sales_quotation.quotation_due_date.strftime("%Y年%m月%d日") %></p>
             <p>納入場所: <%= @sales_quotation.delivery_place %></p>
             <p>納 入 日: <%= @sales_quotation.delivery_date.strftime("%Y年%m月%d日") %></p>
             <p>取引条件: <%= @sales_quotation.trading_conditions %></p>
         </div>
     
-        <div class="pdf-col-md-6 pdf-text-right">
+        <div class="col-md-6 text-right">
             <h6><%= @company_info&.company_name || "未登録" %></h6>
             <p>住所: <%= @company_info&.address || "未登録" %></p>
             <p>電話番号: <%= @company_info&.phone_number || "未登録" %></p>
@@ -40,8 +41,8 @@
             <p>担当: <%= @user.last_name %> <%= @user.first_name %></p>
         </div>
     </div>    
-    <div class="pdf-row">
-        <table class="pdf-table table-bordered table-hover">
+    <div class="row">
+        <table class="table table-bordered table-hover">
             <thead>
                 <tr>
                     <th>No.</th>
@@ -68,8 +69,8 @@
             </tbody>
             <tfoot>
                 <tr>
-                    <td colspan="5" class="pdf-text-right font-weight-bold">合計金額:</td>
-                    <td colspan="2" class="font-weight-bold">
+                    <td colspan="5" class="text-right font-weight-bold">合計金額:</td>
+                    <td colspan="2" class="font-weight-bold ">
                         <%= number_with_delimiter(@sales_quotation.sales_quotation_items.sum { |item| item.quantity * item.unit_price }) %>円
                     </td>
                 </tr>
@@ -77,3 +78,11 @@
         </table>
     </div>
 </div>
+</div>
+
+<style>
+  .download-button,
+  .requote-button {
+    display: none;
+  }
+</style>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -4,8 +4,6 @@ pin "application", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.js"
 pin "stimulus", to: "stimulus.js"
 
-pin_all_from "app/javascript/controllers", under: "controllers" # 追加
-
 pin "controllers/sales_quotation_controller", to: "controllers/sales_quotation_controller.js"
 pin "controllers/amount_controller", to: "controllers/amount_controller.js"
 pin "controllers/hello_controller", to: "controllers/hello_controller.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
     end
   end  
   
-  resources :sales_quotations, only: [:new, :create, :index, :show] do
+  resources :sales_quotations, only: [:new, :create, :index, :show, :edit, :update] do
     collection do
       get :search_customer
       get :new_item


### PR DESCRIPTION
# What

販売見積の再見積機能を追加。
既存の見積もりを基に、新しい見積番号で再見積もりを作成する機能を実装。
再見積もり作成時に、商品やサービス項目の変更・追加・削除が行えるようにした。
顧客や代表者の情報変更も再見積もり時に更新可能とした。

# Why

顧客の要望や市場環境の変化に応じて、見積もり内容の変更が頻繁に求められるため。
再見積もりを新しい見積番号で取得することで、見積履歴の管理と追跡が容易になる。
既存の見積もりを完全にコピーして新しいものを作成する手間を省くため、再見積もり作成機能の導入が必要だった。
商談の進行中に顧客の要望や条件が変わることが多く、それに柔軟に対応するために、商品やサービス項目の内容を簡単に変更できる機能が求められていた。
顧客や代表者の情報変更も再見積もりの際に更新できることで、最新の情報で見積もりを提供することが可能となり、顧客満足度の向上が期待できる。