### PR TITLE
仕入見積作成機能

### DIFF
--- a/app/assets/stylesheets/pdf.css
+++ b/app/assets/stylesheets/pdf.css
@@ -2,111 +2,33 @@ body {
   font-family: 'IPAexMincho', sans-serif !important;
 }
 
-.pdf-quotation-wrapper {
-  border: none !important;
-  padding: 0 !important;
-  box-shadow: none !important;
-  width: auto !important;
-  margin: 0 !important;
-}
-
-h1 {
-  font-size: 2.5em !important;
-}
-
-p {
-  margin-bottom: 5px !important;
-}
-
-tfoot {
-  font-size: 1.2em !important;
-}
-
-.page-break {
-  page-break-after: always !important;
-}
-
-/* テーブルのスタイル調整 */
-th {
-  vertical-align: middle !important;
-  text-align: center !important;
-}
-
-td:nth-child(1), /* No. */
-td:nth-child(3), /* 数量 */
-td:nth-child(5), /* 単価 */
-td:nth-child(6)  /* 金額 */
-{
-  text-align: right !important;
-}
-
-th:nth-child(1) {
-  width: 5% !important; /* No.のセルの幅 */
-}
-
-th:nth-child(2), /* 品名 */
-td:nth-child(2) /* 品名の値 */
-{
-    width: 25% !important; 
-}
-
-th:nth-child(3), /* 数量 */
-td:nth-child(3) /* 数量の値 */
-{
-    width: 10% !important; 
-}
-
-th:nth-child(4), /* 単位 */
-td:nth-child(4) /* 単位の値 */
-{
-    width: 8% !important; 
-}
-
-th:nth-child(5), /* 単価 */
-td:nth-child(5) /* 単価の値 */
-{
-    width: 12% !important; 
-}
-
-th:nth-child(6), /* 金額 */
-td:nth-child(6) /* 金額の値 */
-{
-    width: 18% !important; 
-}
-
-th:nth-child(7), /* 備考 */
-td:nth-child(7) /* 備考の値 */
-{
-    width: 20% !important; 
-}
-
-/* BootstrapのGridシステムの模倣 */
-.pdf-container-fluid {
-  width: 100% !important;
+/* Bootstrap Grid の上書き */
+.container-fluid {
   padding-right: 15px !important;
   padding-left: 15px !important;
-  margin-right: auto !important;
-  margin-left: auto !important;
+  width: 100% !important;
 }
 
-.pdf-row {
+.row {
   margin-right: -15px !important;
   margin-left: -15px !important;
 }
 
-.pdf-col-md-6 {
-  width: 50% !important;
+/* floatを使用してレイアウト */
+.col-md-6 {
   float: left !important;
+  width: 50% !important;
+  position: relative !important;
   padding-right: 15px !important;
   padding-left: 15px !important;
-  box-sizing: border-box !important;
+  box-sizing: border-box;
 }
 
-.pdf-text-center {
+.text-center {
   text-align: center !important;
 }
 
-.pdf-text-right {
+.text-right {
   text-align: right !important;
 }
 
@@ -126,25 +48,26 @@ td:nth-child(7) /* 備考の値 */
   border-radius: 0.25rem !important;
 }
 
-.pdf-table {
+.table {
   width: 100% !important;
   margin-bottom: 1rem !important;
   border-collapse: collapse !important;
 }
 
-.pdf-table th,
-.pdf-table td {
+.table th,
+.table td {
   border: 1px solid #dee2e6 !important;
   padding: 0.75rem !important;
   vertical-align: top !important;
-}
-
-.table-bordered {
-  border: 1px solid #dee2e6 !important;
 }
 
 .font-weight-bold {
   font-weight: bold !important;
 }
 
-
+/* floatを解除するためのヘルパー */
+.clearfix::after {
+  content: "";
+  display: table;
+  clear: both;
+}

--- a/app/controllers/purchase_quotations_controller.rb
+++ b/app/controllers/purchase_quotations_controller.rb
@@ -1,0 +1,190 @@
+class PurchaseQuotationsController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_purchase_quotation, only: [:show, :edit, :update]
+  
+
+  def new
+    @purchase_quotation = PurchaseQuotation.new
+    @customers = Customer.all.pluck(:customer_name, :id)
+    @representatives = Representative.all.map { |r| [r.department_name + ' - ' + r.representative_name, r.id] }
+    20.times { @purchase_quotation.purchase_quotation_items.build } unless @purchase_quotation.purchase_quotation_items.size >= 20
+  end  
+
+  def create
+    @purchase_quotation = PurchaseQuotation.new(purchase_quotation_params)
+    @purchase_quotation.quotation_number = generate_new_quotation_number
+
+    @purchase_quotation.purchase_quotation_items = @purchase_quotation.purchase_quotation_items.reject do |item|
+      item.category_id.blank? &&
+      item.item_name.blank? &&
+      item.quantity.blank? &&
+      item.unit_id.blank? &&
+      item.unit_price.blank? &&
+      item.note.blank?
+    end
+    
+    respond_to do |format|
+      begin
+        if @purchase_quotation.save
+          format.html { redirect_to purchase_quotation_path(@purchase_quotation), notice: 'purchase quotation was successfully created and show is ready.' }
+          format.json { render :show, status: :created, location: @purchase_quotation }
+        else
+          @customers = Customer.all
+          @representatives = Representative.all
+          format.html { render :new }
+          format.json { render json: @purchase_quotation.errors, status: :unprocessable_entity }
+    
+        end
+      rescue => e
+        logger.error "Error in creating purchase quotation: #{e.message}"
+        raise e
+      end
+    end
+  end
+  
+  
+  def index
+    @purchase_quotations = PurchaseQuotation.includes(purchase_quotation_items: [:unit, :category])
+  
+    # 顧客名での検索
+    if params[:customer_name].present?
+      @purchase_quotations = @purchase_quotations.joins(:customer).where("customers.customer_name LIKE ?", "%#{params[:customer_name]}%")
+    end
+  
+    # 見積番号での検索
+    if params[:quotation_number].present?
+      @purchase_quotations = @purchase_quotations.where(quotation_number: params[:quotation_number])
+    end
+  
+    # カテゴリーでの検索
+    if params[:category_name].present?
+      @purchase_quotations = @purchase_quotations.joins(purchase_quotation_items: :category).where("categories.category_name LIKE ?", "%#{params[:category_name]}%")
+    end
+  
+    # 品名での検索
+    if params[:item_name].present?
+      @purchase_quotations = @purchase_quotations.joins(:purchase_quotation_items).where("purchase_quotation_items.item_name LIKE ?", "%#{params[:item_name]}%")
+    end
+  
+    # 最後にソートとページネーションを適用
+    @purchase_quotations = @purchase_quotations.order(created_at: :desc).page(params[:page]).per(20)
+  end
+  
+
+  def show
+    @purchase_quotation = PurchaseQuotation.find(params[:id])
+    @customer = @purchase_quotation.customer
+    @company_info = CompanyInfo.first
+    @user = @purchase_quotation.user
+
+    respond_to do |format|
+      format.html
+      format.pdf do
+        render pdf: "purchase_quotations/show",
+               template: "purchase_quotations/show",
+               encoding: "UTF-8",
+               font_name: "IPAexMincho",
+               formats: [:pdf],
+               layout: 'pdf',
+               disposition: 'attachment' # ブラウザでPDFを開くのではなく、ダウンロードさせる
+      end
+    end
+  end
+
+  def edit
+    puts "Edit action is being called"
+    @purchase_quotation = PurchaseQuotation.find(params[:id])
+    @purchase_quotation_items = @purchase_quotation.purchase_quotation_items
+    
+    # 既存のアイテム数に基づいて追加の行を作成
+    additional_rows = 20 - @purchase_quotation_items.size
+    additional_rows.times { @purchase_quotation.purchase_quotation_items.build } if additional_rows > 0
+  
+    @customers = Customer.all.pluck(:customer_name, :id)
+    @representatives = Representative.all.map { |r| [r.department_name + ' - ' + r.representative_name, r.id] }
+  end
+  
+  def update
+    @purchase_quotation = PurchaseQuotation.find(params[:id])
+  
+    if @purchase_quotation.update(purchase_quotation_params)
+      # 新しい見積番号を生成
+      new_quotation = @purchase_quotation.dup
+      new_quotation.quotation_number = generate_new_quotation_number
+      new_quotation.purchase_quotation_items = @purchase_quotation.purchase_quotation_items.map(&:dup) # この行をここに移動
+  
+      # customer_id、representative_id、その他の属性を設定
+      new_quotation.customer_id = params[:purchase_quotation][:customer_id]
+      new_quotation.representative_id = params[:purchase_quotation][:representative_id]
+  
+      if new_quotation.save
+        redirect_to purchase_quotation_path(@purchase_quotation), notice: 'purchase quotation was successfully created and show is ready.'
+      else
+        puts new_quotation.errors.full_messages # この行を追加
+        new_quotation.purchase_quotation_items.each do |item|
+          puts item.errors.full_messages
+        end
+        @representatives = Representative.all.map { |r| [r.department_name + ' - ' + r.representative_name, r.id] }
+        @purchase_quotation_items = @purchase_quotation.purchase_quotation_items
+        flash.now[:alert] = '新しい見積の作成に失敗しました。'
+        render :edit
+      end
+    else
+      render :edit
+    end
+  end
+  
+  
+
+  def new_item
+    @purchase_quotation = PurchaseQuotation.new
+    @purchase_quotation.purchase_quotation_items.build
+    render partial: 'purchase_quotation_item_fields', locals: { f: @purchase_quotation.purchase_quotation_items.last }
+  end
+
+  private
+
+  def set_purchase_quotation
+    @purchase_quotation = PurchaseQuotation.find(params[:id])
+  end
+
+  def purchase_quotation_params
+    params.require(:purchase_quotation).permit(
+      :customer_id,
+      :representative_id, 
+      :request_date, 
+      :quotation_date, 
+      :quotation_due_date, 
+      :delivery_date, 
+      :handover_place, 
+      :trading_conditions,
+      purchase_quotation_items_attributes: [
+        :id, 
+        :item_name, 
+        :quantity, 
+        :category_id, 
+        :unit_id, 
+        :unit_price, 
+        :note, 
+        :_destroy
+      ]
+    ).merge(user_id: current_user.id)
+  end
+
+  def representative_options
+    customer = Customer.find(params[:id])
+    @representatives = customer.representatives
+    render partial: "representative_options", locals: { representatives: @representatives }
+  end
+
+  def generate_new_quotation_number
+    date_prefix = Date.today.strftime('P%Y%m%d-')
+    last_quotation = PurchaseQuotation.where('quotation_number LIKE ?', "#{date_prefix}%").order(:quotation_number).last
+    if last_quotation.nil?
+      "#{date_prefix}001"
+    else
+      number = last_quotation.quotation_number.split('-').last.to_i
+      "#{date_prefix}#{sprintf('%03d', number + 1)}"
+    end
+  end
+end

--- a/app/controllers/sales_quotations_controller.rb
+++ b/app/controllers/sales_quotations_controller.rb
@@ -106,11 +106,12 @@ class SalesQuotationsController < ApplicationController
   
   def update
     @sales_quotation = SalesQuotation.find(params[:id])
-  
+
     if @sales_quotation.update(sales_quotation_params)
       # 新しい見積番号を生成
       new_quotation = @sales_quotation.dup
       new_quotation.quotation_number = generate_new_quotation_number
+      new_quotation.sales_quotation_items = @sales_quotation.sales_quotation_items.map(&:dup)
   
       # customer_id、representative_id、その他の属性を設定
       new_quotation.customer_id = params[:sales_quotation][:customer_id]

--- a/app/javascript/sales_quotation.js
+++ b/app/javascript/sales_quotation.js
@@ -35,4 +35,5 @@ document.addEventListener("DOMContentLoaded", function() {
       console.log('すべての行が表示されました');
     }
   });
+  addRowsButton.click();
 });

--- a/app/models/purchase_quotation.rb
+++ b/app/models/purchase_quotation.rb
@@ -1,0 +1,34 @@
+class PurchaseQuotation < ApplicationRecord
+  belongs_to :customer
+  belongs_to :user
+  has_many :purchase_quotation_items, inverse_of: :purchase_quotation, dependent: :destroy
+  validates_associated :purchase_quotation_items
+  belongs_to :representative, optional: true
+  has_many :comments
+
+  accepts_nested_attributes_for :purchase_quotation_items, reject_if: :all_blank, allow_destroy: true
+  validates :quotation_number, uniqueness: { case_sensitive: true }
+  validates :customer_id, :user_id, :request_date, :quotation_date, :quotation_due_date, presence: true
+  validate :quotation_due_date_after_quotation_date
+
+  def generate_new_quotation_number
+    date_prefix = Date.today.strftime('P%Y%m%d-')
+    last_quotation = PurchaseQuotation.where('quotation_number LIKE ?', "#{date_prefix}%").order(:quotation_number).last
+    if last_quotation.nil?
+      "#{date_prefix}001"
+    else
+      number = last_quotation.quotation_number.split('-').last.to_i
+      "#{date_prefix}#{sprintf('%03d', number + 1)}"
+    end
+  end
+
+  private
+
+  def quotation_due_date_after_quotation_date
+    return if quotation_due_date.blank? || quotation_date.blank?
+
+    if quotation_due_date < quotation_date
+      errors.add(:quotation_due_date, "must be after the quotation date")
+    end
+  end
+end

--- a/app/models/purchase_quotation_item.rb
+++ b/app/models/purchase_quotation_item.rb
@@ -1,0 +1,9 @@
+class PurchaseQuotationItem < ApplicationRecord
+  belongs_to :purchase_quotation
+  belongs_to :unit
+  belongs_to :category
+
+
+  validates :purchase_quotation, :category, :item_name, :unit_id, presence: true
+  validates :quantity, :unit_price, presence: true, numericality: { greater_than: 0 }
+end

--- a/app/views/estimates/index.html.erb
+++ b/app/views/estimates/index.html.erb
@@ -6,13 +6,16 @@
                 <i class="fas fa-shopping-cart"></i> 販売見積作成
               <% end %>
               <%= link_to(sales_quotations_path, class: 'btn btn-primary btn-lg btn-block') do %>
-                <i class="fas fa-list-ul"></i> 販売見積一覧</button>
+                <i class="fas fa-list-ul"></i> 販売見積一覧
               <% end %>
             </div>  
             <div class="col-sm">
-                <button class="btn btn-secondary btn-lg btn-block"><i class="fas fa-hammer"></i> 仕入見積作成</button>
-                <button class="btn btn-secondary btn-lg btn-block"><i class="fas fa-list-ul"></i> 仕入見積一覧</button>
-            </div>
+            <%= link_to(new_purchase_quotation_path, class: 'btn btn-secondary btn-lg btn-block') do %>
+                <i class="fas fa-hammer"></i> 仕入見積作成</button>
+            <% end %>
+            <%= link_to(purchase_quotations_path, class: 'btn btn-secondary btn-lg btn-block') do %>  
+                <i class="fas fa-list-ul"></i> 仕入見積一覧
+            <% end %>
         </div>
         <div class="row button-row mb-2">
             <div class="col-sm">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,5 +19,6 @@
 
   <%= yield %>
   
+  <%= render "shared/footer" %>
 </body>
 </html>

--- a/app/views/purchase_quotations/_purchase_quotation_item_fields.html.erb
+++ b/app/views/purchase_quotations/_purchase_quotation_item_fields.html.erb
@@ -1,0 +1,19 @@
+
+<tr class="nested-fields" data-controller="amount">
+    <td class="col-2">
+      <%= f.select :category_id, [['', '']] + Category.all.map { |c| [c.category_name, c.id] }, {}, class: "form-control" %>
+    </td>
+    <td class="col-2"><%= f.text_field :item_name, class: "form-control" %></td>
+    <td class="col-2">
+      <%= f.number_field :quantity, class: "form-control quantity", data: { action: "input->amount#calculate" } %>
+    </td>
+    <td class="col-1">
+      <%= f.select :unit_id, [['', '']] + Unit.all.map { |u| [u.unit_name, u.id] }, {}, class: "form-control" %>
+    </td>
+    <td class="col-2">
+      <%= f.number_field :unit_price, class: "form-control unit_price", data: { action: "input->amount#calculate" } %>
+    </td>
+
+    <td class="col-2"><%= content_tag :span, "", class: "amount" %></td>
+    <td class="col-2"><%= f.text_field :note, class: "form-control" %></td>
+  </tr>

--- a/app/views/purchase_quotations/_representative_options.html.erb
+++ b/app/views/purchase_quotations/_representative_options.html.erb
@@ -1,0 +1,5 @@
+<%= turbo_frame_tag "representative_options" do %>
+  <% representatives.each do |rep| %>
+    <option value="<%= rep.id %>"><%= rep.department_name %> - <%= rep.representative_name %></option>
+  <% end %>
+<% end %>

--- a/app/views/purchase_quotations/edit.html.erb
+++ b/app/views/purchase_quotations/edit.html.erb
@@ -1,0 +1,78 @@
+<div class="container mt-5">
+
+  <% if @purchase_quotation.errors.any? %>
+    <div class="alert alert-danger">
+      <h4><%= pluralize(@purchase_quotation.errors.count, "error") %> prohibited this purchase_quotation from being saved:</h4>
+      <ul>
+        <% @purchase_quotation.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="d-flex justify-content-center mt-4">
+    <h2>仕入見積</h2>
+  </div>
+
+  <div class="card">
+    <div class="card-body">
+      <%= form_with model: @purchase_quotation do |form| %>
+        <div class="form-group">
+          <%= form.label :quotation_number, "見積番号" %>
+          <%= form.text_field :quotation_number, class: "form-control", disabled: true %>
+          <%= form.label :customer_id, "顧客名" %>
+          <%= form.collection_select :customer_id, Customer.all, :id, :customer_name, { include_blank: '選択してください' }, class: "form-control", selected: @purchase_quotation.customer_id %>
+          <%= form.label :representative_id, "部署名 - 担当者名" %>
+          <%= form.select :representative_id, options_for_select(@representatives, @purchase_quotation.representative_id), { include_blank: '-' }, class: "form-control", data: { target: "purchase-quotation.representativeSelect" } %>
+          <%= form.label :handover_place, "受渡場所" %>
+          <%= form.text_field :handover_place, class: "form-control" %>
+          <%= form.label :request_date, "見積依頼日" %>
+          <%= form.date_field :request_date, class: "form-control" %>
+          <%= form.label :quotation_date, "見積作成日" %>
+          <%= form.date_field :quotation_date, class: "form-control" %>
+          <%= form.label :quotation_due_date, "見積有効期限" %>
+          <%= form.date_field :quotation_due_date, class: "form-control" %>
+          <%= form.label :delivery_date, "受渡日" %>
+          <%= form.date_field :delivery_date, class: "form-control" %>
+          <%= form.label :trading_conditions, "取引条件" %>
+          <%= form.text_field :trading_conditions, class: "form-control" %>
+        </div>
+
+        <table class="table table-bordered mt-4" data-action-type="edit">
+          <thead>
+            <tr>
+              <th class="col-2">カテゴリ</th>
+              <th class="col-2">品名</th>
+              <th class="col-2">数量</th>
+              <th class="col-1">単位</th>
+              <th class="col-2">単価</th>
+              <th class="col-2">金額</th>
+              <th class="col-2">備考</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @purchase_quotation_items.each do |item| %>
+              <%= form.fields_for :purchase_quotation_items, item do |item_fields| %>
+                <%= render 'purchase_quotation_item_fields', f: item_fields %>
+              <% end %>
+            <% end %>
+          </tbody>
+        </table>
+
+        <button type="button" id="addRows" class="btn btn-primary btn-sm">
+          <i class="fas fa-plus"></i> 行を追加
+        </button>
+
+
+        <div class="d-flex justify-content-center mt-4">
+          <%= form.submit "作成", class: "btn btn-primary" %>
+        </div>
+
+      <% end %> 
+    </div>
+  </div>
+
+  <%= javascript_include_tag 'sales_quotation' %>
+
+</div>

--- a/app/views/purchase_quotations/index.html.erb
+++ b/app/views/purchase_quotations/index.html.erb
@@ -1,0 +1,66 @@
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-md-12">
+      <h2>Sales Quotations</h2>
+
+      <!-- Search form -->
+      <div class="my-3">
+        <%= form_with url: purchase_quotations_path, method: :get, local: true do |f| %>
+          <div class="row">
+            <div class="col-md-2">
+              <%= f.label :customer_name, "顧客名" %>
+              <%= f.text_field :customer_name, class: "form-control" %>
+            </div>
+
+            <div class="col-md-2">
+              <%= f.label :quotation_number, "見積番号" %>
+              <%= f.text_field :quotation_number, class: "form-control" %>
+            </div>
+
+            <div class="col-md-2">
+              <%= f.label :category, "カテゴリー" %>
+              <%= f.text_field :category, class: "form-control" %>
+            </div>
+
+            <div class="col-md-2">
+              <%= f.label :item_name, "品名" %>
+              <%= f.text_field :item_name, class: "form-control" %>
+            </div>
+
+            <div class="col-md-2 align-self-end">
+              <%= f.submit "検索", class: "btn btn-primary" %>
+              <%= link_to "リセット", purchase_quotations_path, class: "btn btn-secondary ml-2" %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <table class="table table-bordered table-custom-height">
+        <thead>
+          <tr>
+            <th class="col-date">作成日</th>
+            <th class="col-customer">顧客名</th>
+            <th class="col-number">見積番号</th>
+            <th class="col-category">カテゴリー</th>
+            <th class="col-item-name">品名</th>
+            <th class="col-unit-price">単価</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <% @purchase_quotations.each do |quotation| %>
+            <tr>
+              <td><%= quotation.quotation_date %></td>
+              <td><%= quotation.customer.customer_name %></td>
+              <td><%= link_to quotation.quotation_number, purchase_quotation_path(quotation) %></td>
+              <td><%= quotation.purchase_quotation_items.first&.category&.category_name %></td>
+              <td><%= quotation.purchase_quotation_items.first&.item_name %></td>
+              <td style="text-align: right;"><%= number_with_delimiter(quotation.purchase_quotation_items.first&.unit_price) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= paginate @purchase_quotations %>
+    </div>
+  </div>
+</div>

--- a/app/views/purchase_quotations/new.html.erb
+++ b/app/views/purchase_quotations/new.html.erb
@@ -1,0 +1,78 @@
+<div class="container mt-5">
+
+  <% if @purchase_quotation.errors.any? %>
+    <div class="alert alert-danger">
+      <h4><%= pluralize(@purchase_quotation.errors.count, "error") %> prohibited this purchase_quotation from being saved:</h4>
+      <ul>
+        <% @purchase_quotation.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="d-flex justify-content-center mt-4">
+    <h2>仕入見積</h2>
+  </div>
+
+  <div class="card">
+    <div class="card-body">
+      <%= form_with model: @purchase_quotation do |form| %>
+        <div class="form-group">
+          <%= form.label :quotation_number, "見積番号" %>
+          <%= form.text_field :quotation_number, class: "form-control", disabled: true %>
+
+          <div data-controller="purchase_quotation">
+            <%= form.label :customer_id, "顧客名" %>
+            <%= form.select :customer_id, options_for_select(@customers), { include_blank: '選択してください' }, class: "form-control", data: { action: "change->purchase-quotation#fetchRepresentatives" } %>
+            
+            <%= form.label :representative_id, "部署名 - 担当者名" %>
+            <%= turbo_frame_tag "representative_options" do %>
+              <%= form.select :representative_id, options_for_select(@representatives), { include_blank: '-' }, class: "form-control", data: { target: "purchase-quotation.representativeSelect" } %>
+            <% end %>
+          </div>
+
+          <%= form.label :handover_place, "受渡場所" %>
+          <%= form.text_field :handover_place, class: "form-control" %>
+          <%= form.label :request_date, "見積依頼日" %>
+          <%= form.date_field :request_date, class: "form-control" %>
+          <%= form.label :quotation_date, "見積作成日" %>
+          <%= form.date_field :quotation_date, class: "form-control" %>
+          <%= form.label :quotation_due_date, "見積有効期限" %>
+          <%= form.date_field :quotation_due_date, class: "form-control" %>
+          <%= form.label :delivery_date, "受渡日" %>
+          <%= form.date_field :delivery_date, class: "form-control" %>
+          <%= form.label :trading_conditions, "取引条件" %>
+          <%= form.text_field :trading_conditions, class: "form-control" %>
+        </div>
+
+        <table class="table table-bordered mt-4">
+          <thead>
+            <tr>
+              <th class="col-2">カテゴリ</th>
+              <th class="col-2">品名</th>
+              <th class="col-2">数量</th>
+              <th class="col-1">単位</th>
+              <th class="col-2">単価</th>
+              <th class="col-2">金額</th>
+              <th class="col-2">備考</th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= form.fields_for :purchase_quotation_items do |item_fields| %>
+              <%= render 'purchase_quotation_item_fields', f: item_fields %>
+            <% end %>
+          </tbody>
+        </table>
+
+        <button type="button" id="addRows" class="btn btn-primary btn-sm">
+          <i class="fas fa-plus"></i> 行を追加
+        </button>
+
+        <div class="d-flex justify-content-center mt-4">
+          <%= form.submit "作成", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+     <%= javascript_include_tag 'sales_quotation' %>
+  </div>

--- a/app/views/purchase_quotations/show.html.erb
+++ b/app/views/purchase_quotations/show.html.erb
@@ -1,11 +1,16 @@
+<div class="btn-group" role="group" aria-label="ボタングループ">
+    <%= link_to 'PDFでダウンロード', purchase_quotation_path(@purchase_quotation, format: :pdf), class: 'btn btn-primary download-button' %>
+    <%= link_to '再見積', edit_purchase_quotation_path(@purchase_quotation), class: 'btn btn-success requote-button' %>
+</div>
+
 <div class="pdf-quotation-wrapper">
 <div class="text-center">
-    <h1>販売見積書</h1>
+    <h1>仕入見積書</h1>
 </div>
 <div class="container-fluid">
-    <div class="row clearfix mb-5 p-3 rounded">
+    <div class="row mb-5 p-3 rounded">
         <div class="col-md-6">
-            <% representative = @sales_quotation.representative %>
+            <% representative = @purchase_quotation.representative %>
             <h2>
                 <%= @customer.customer_name %>
             </h2>
@@ -21,16 +26,16 @@
             </h4>
         </div>
         <div class="col-md-6 text-right">
-            <p>見 積 日: <%= @sales_quotation.quotation_date.strftime("%Y年%m月%d日") %></p>
-            <p>見積番号: <%= @sales_quotation.quotation_number %></p>
+            <p>見 積 日: <%= @purchase_quotation.quotation_date.strftime("%Y年%m月%d日") %></p>
+            <p>見積番号: <%= @purchase_quotation.quotation_number %></p>
         </div>
     </div>
-    <div class="row clearfix mb-4">
+    <div class="row mb-4">
         <div class="col-md-6">
-            <p>有効期限: <%= @sales_quotation.quotation_due_date.strftime("%Y年%m月%d日") %></p>
-            <p>納入場所: <%= @sales_quotation.delivery_place %></p>
-            <p>納 入 日: <%= @sales_quotation.delivery_date.strftime("%Y年%m月%d日") %></p>
-            <p>取引条件: <%= @sales_quotation.trading_conditions %></p>
+            <p>有効期限: <%= @purchase_quotation.quotation_due_date.strftime("%Y年%m月%d日") %></p>
+            <p>受渡場所: <%= @purchase_quotation.handover_place %></p>
+            <p>受 渡 日: <%= @purchase_quotation.delivery_date.strftime("%Y年%m月%d日") %></p>
+            <p>取引条件: <%= @purchase_quotation.trading_conditions %></p>
         </div>
     
         <div class="col-md-6 text-right">
@@ -41,7 +46,7 @@
             <p>担当: <%= @user.last_name %> <%= @user.first_name %></p>
         </div>
     </div>    
-    <div class="row clearfix">
+    <div class="row">
         <table class="table table-bordered table-hover">
             <thead>
                 <tr>
@@ -55,7 +60,7 @@
                 </tr>
             </thead>
             <tbody>
-                <% @sales_quotation.sales_quotation_items.each_with_index do |item, index| %>
+                <% @purchase_quotation.purchase_quotation_items.each_with_index do |item, index| %>
                 <tr>
                     <td><%= index + 1 %></td>
                     <td><%= item.item_name %></td>
@@ -71,7 +76,7 @@
                 <tr>
                     <td colspan="5" class="text-right font-weight-bold">合計金額:</td>
                     <td colspan="2" class="font-weight-bold ">
-                        <%= number_with_delimiter(@sales_quotation.sales_quotation_items.sum { |item| item.quantity * item.unit_price }) %>円
+                        <%= number_with_delimiter(@purchase_quotation.purchase_quotation_items.sum { |item| item.quantity * item.unit_price }) %>円
                     </td>
                 </tr>
             </tfoot>
@@ -79,10 +84,3 @@
     </div>
 </div>
 </div>
-
-<style>
-  .download-button,
-  .requote-button {
-    display: none;
-  }
-</style>

--- a/app/views/purchase_quotations/show.pdf.erb
+++ b/app/views/purchase_quotations/show.pdf.erb
@@ -1,11 +1,11 @@
 <div class="pdf-quotation-wrapper">
 <div class="text-center">
-    <h1>販売見積書</h1>
+    <h1>仕入見積書</h1>
 </div>
 <div class="container-fluid">
-    <div class="row clearfix mb-5 p-3 rounded">
+    <div class="row mb-5 p-3 rounded">
         <div class="col-md-6">
-            <% representative = @sales_quotation.representative %>
+            <% representative = @purchase_quotation.representative %>
             <h2>
                 <%= @customer.customer_name %>
             </h2>
@@ -21,16 +21,16 @@
             </h4>
         </div>
         <div class="col-md-6 text-right">
-            <p>見 積 日: <%= @sales_quotation.quotation_date.strftime("%Y年%m月%d日") %></p>
-            <p>見積番号: <%= @sales_quotation.quotation_number %></p>
+            <p>見 積 日: <%= @purchase_quotation.quotation_date.strftime("%Y年%m月%d日") %></p>
+            <p>見積番号: <%= @purchase_quotation.quotation_number %></p>
         </div>
     </div>
-    <div class="row clearfix mb-4">
+    <div class="row mb-4">
         <div class="col-md-6">
-            <p>有効期限: <%= @sales_quotation.quotation_due_date.strftime("%Y年%m月%d日") %></p>
-            <p>納入場所: <%= @sales_quotation.delivery_place %></p>
-            <p>納 入 日: <%= @sales_quotation.delivery_date.strftime("%Y年%m月%d日") %></p>
-            <p>取引条件: <%= @sales_quotation.trading_conditions %></p>
+            <p>有効期限: <%= @purchase_quotation.quotation_due_date.strftime("%Y年%m月%d日") %></p>
+            <p>受渡場所: <%= @purchase_quotation.handover_place %></p>
+            <p>受 渡 日: <%= @purchase_quotation.delivery_date.strftime("%Y年%m月%d日") %></p>
+            <p>取引条件: <%= @purchase_quotation.trading_conditions %></p>
         </div>
     
         <div class="col-md-6 text-right">
@@ -41,7 +41,7 @@
             <p>担当: <%= @user.last_name %> <%= @user.first_name %></p>
         </div>
     </div>    
-    <div class="row clearfix">
+    <div class="row">
         <table class="table table-bordered table-hover">
             <thead>
                 <tr>
@@ -55,7 +55,7 @@
                 </tr>
             </thead>
             <tbody>
-                <% @sales_quotation.sales_quotation_items.each_with_index do |item, index| %>
+                <% @purchase_quotation.purchase_quotation_items.each_with_index do |item, index| %>
                 <tr>
                     <td><%= index + 1 %></td>
                     <td><%= item.item_name %></td>
@@ -71,7 +71,7 @@
                 <tr>
                     <td colspan="5" class="text-right font-weight-bold">合計金額:</td>
                     <td colspan="2" class="font-weight-bold ">
-                        <%= number_with_delimiter(@sales_quotation.sales_quotation_items.sum { |item| item.quantity * item.unit_price }) %>円
+                        <%= number_with_delimiter(@purchase_quotation.purchase_quotation_items.sum { |item| item.quantity * item.unit_price }) %>円
                     </td>
                 </tr>
             </tfoot>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,16 @@
+<!-- _footer.html.erb -->
+<style>
+  .footer-bar {
+    background-color: lavender; /* 背景色をラベンダーに設定 */
+    color: midnightblue;        /* 文字色をmidnightblueに設定 */
+    font-size: 16px;            /* 文字サイズを16pxに設定 (例) */
+    height: 50px;               /* バーの縦幅を50pxに設定 (例) */
+    display: flex;
+    align-items: center;        /* 中央に配置するための設定 */
+    justify-content: center;    /* 中央に配置するための設定 */
+  }
+</style>
+
+<div class="footer-bar">
+  ©2003 MZK_TKHS
+</div>

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -1,5 +1,3 @@
-<%= render "shared/header"%>
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
 <h3>単位一覧</h3>
 
 <div class="container">

--- a/app/views/units/new.html.erb
+++ b/app/views/units/new.html.erb
@@ -1,6 +1,3 @@
-<%= render "shared/header" %>
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
-
 <div class="container mt-5">
   <div class="row justify-content-center">
     <div class="col-md-6">

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -12,4 +12,5 @@ WickedPdf.config = {
   exe_path: "#{Gem.loaded_specs['wkhtmltopdf-binary-edge'].full_gem_path}/bin/wkhtmltopdf",
   dpi: '300',
   default_font: 'IPAexMincho'
+  zoom: '1.3',
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,14 @@ Rails.application.routes.draw do
       get :preview
     end
   end
+
+  resources :purchase_quotations, only: [:new, :create, :index, :show, :edit, :update] do
+    collection do
+      get :search_customer
+      get :new_item
+      get :representative_options
+    end
+  end
   
   resources :categories, only: [:new, :create, :index]
   

--- a/db/migrate/20230821115622_add_representative_id_to_sales_quotations.rb
+++ b/db/migrate/20230821115622_add_representative_id_to_sales_quotations.rb
@@ -1,5 +1,0 @@
-class AddRepresentativeIdToSalesQuotations < ActiveRecord::Migration[7.0]
-  def change
-    add_column :sales_quotations, :representative_id, :integer
-  end
-end

--- a/db/migrate/20230821115943_remove_representative_from_sales_quotations.rb
+++ b/db/migrate/20230821115943_remove_representative_from_sales_quotations.rb
@@ -1,5 +1,0 @@
-class RemoveRepresentativeFromSalesQuotations < ActiveRecord::Migration[7.0]
-  def change
-    remove_column :sales_quotations, :representative
-  end
-end

--- a/db/migrate/20230903201209_create_purchase_quotations.rb
+++ b/db/migrate/20230903201209_create_purchase_quotations.rb
@@ -1,6 +1,6 @@
-class CreateSalesQuotations < ActiveRecord::Migration[6.0]
+class CreatePurchaseQuotations < ActiveRecord::Migration[7.0]
   def change
-    create_table :sales_quotations do |t|
+    create_table :purchase_quotations do |t|
       t.references :customer, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true
       t.string :quotation_number, null: false
@@ -8,13 +8,12 @@ class CreateSalesQuotations < ActiveRecord::Migration[6.0]
       t.date :quotation_date, null: false
       t.date :quotation_due_date, null: false
       t.date :delivery_date, null: false
-      t.string :delivery_place
+      t.string :handover_place
       t.string :trading_conditions
       t.references :representative, foreign_key: true
       t.string :result
       t.timestamps
     end
-    add_index :sales_quotations, :quotation_number, unique: true
+    add_index :purchase_quotations, :quotation_number, unique: true
   end
 end
-

--- a/db/migrate/20230903201944_create_purchase_quotation_items.rb
+++ b/db/migrate/20230903201944_create_purchase_quotation_items.rb
@@ -1,0 +1,15 @@
+class CreatePurchaseQuotationItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :purchase_quotation_items do |t|
+      t.bigint :purchase_quotation_id, null: false, foreign_key: {to_table: :purchase_quotations}
+      t.string :item_name, null: false
+      t.integer :quantity, null: false
+      t.references :category, null: false, foreign_key: true
+      t.references :unit, null: false, foreign_key: true
+      t.integer :unit_price, null: false
+      t.string :note
+      t.string :result
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_21_115943) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_03_201944) do
   create_table "categories", charset: "utf8", force: :cascade do |t|
     t.string "category_name", null: false
     t.datetime "created_at", null: false
@@ -36,6 +36,40 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_115943) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["customer_code"], name: "index_customers_on_customer_code", unique: true
+  end
+
+  create_table "purchase_quotation_items", charset: "utf8", force: :cascade do |t|
+    t.bigint "purchase_quotation_id", null: false
+    t.string "item_name", null: false
+    t.integer "quantity", null: false
+    t.bigint "category_id", null: false
+    t.bigint "unit_id", null: false
+    t.integer "unit_price", null: false
+    t.string "note"
+    t.string "result"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_purchase_quotation_items_on_category_id"
+    t.index ["unit_id"], name: "index_purchase_quotation_items_on_unit_id"
+  end
+
+  create_table "purchase_quotations", charset: "utf8", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.bigint "user_id", null: false
+    t.string "quotation_number", null: false
+    t.date "request_date", null: false
+    t.date "quotation_date", null: false
+    t.date "quotation_due_date", null: false
+    t.date "delivery_date", null: false
+    t.string "handover_place"
+    t.string "trading_conditions"
+    t.integer "representative_id"
+    t.string "result"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_purchase_quotations_on_customer_id"
+    t.index ["quotation_number"], name: "index_purchase_quotations_on_quotation_number", unique: true
+    t.index ["user_id"], name: "index_purchase_quotations_on_user_id"
   end
 
   create_table "representatives", charset: "utf8", force: :cascade do |t|
@@ -74,9 +108,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_115943) do
     t.date "delivery_date", null: false
     t.string "delivery_place"
     t.string "trading_conditions"
+    t.integer "representative_id"
+    t.string "result"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "representative_id"
     t.index ["customer_id"], name: "index_sales_quotations_on_customer_id"
     t.index ["quotation_number"], name: "index_sales_quotations_on_quotation_number", unique: true
     t.index ["user_id"], name: "index_sales_quotations_on_user_id"
@@ -103,6 +138,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_115943) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "purchase_quotation_items", "categories"
+  add_foreign_key "purchase_quotation_items", "units"
+  add_foreign_key "purchase_quotations", "customers"
+  add_foreign_key "purchase_quotations", "users"
   add_foreign_key "representatives", "customers"
   add_foreign_key "sales_quotation_items", "categories"
   add_foreign_key "sales_quotation_items", "units"


### PR DESCRIPTION
# What
- 新規仕入見積作成
ユーザーは新規の仕入れ見積を作成することができる。
- PDF出力機能
作成された仕入れ見積をPDF形式で出力することが可能。
- 仕入見積一覧機能
既存の仕入れ見積の一覧を表示し、特定の見積を検索・選択することができる。
- 仕入見積再見積機能
既存の仕入れ見積に対して、再見積を行うことができる。
- 仕入見積作成テストコード
上記機能が正確に動作することを保証するためのテストコードを追加。

# Why
新規仕入見積作成は、新たな仕入れの際に見積を行うための基本的な機能である。

PDF出力機能により、仕入れ見積を電子ファイルや紙として持ち運びや共有が可能になる。特に外部の取引先などとのやり取りにおいて役立つ。

仕入見積一覧機能は、現在の仕入れ見積の状況を一目で確認できるためのもの。また、過去の見積も参照できるため、履歴管理にも寄与する。

仕入見積再見積機能は、仕入れ条件や市場の状況が変わった場合に柔軟に対応するための機能である。再見積を簡単に行えることで、時間の短縮や誤算を防ぐことができる。

仕入見積テストコードは、機能追加や更新を行った際の不具合を事前に発見し、品質を保つためのものである。