### PR TITLE
顧客詳細ページから見積作成機能

### DIFF
--- a/app/controllers/sales_quotations_controller.rb
+++ b/app/controllers/sales_quotations_controller.rb
@@ -6,9 +6,11 @@ class SalesQuotationsController < ApplicationController
   
 
   def new
-    @sales_quotation = SalesQuotation.new
+    @customer = params[:customer_id] ? Customer.find(params[:customer_id]) : nil
+    @sales_quotation = @customer ? @customer.sales_quotations.build : SalesQuotation.new
     20.times { @sales_quotation.sales_quotation_items.build } unless @sales_quotation.sales_quotation_items.size >= 20
-  end  
+  end
+  
 
   def create
     @sales_quotation = SalesQuotation.new(sales_quotation_params)

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,4 +1,6 @@
 class Customer < ApplicationRecord
+  has_many :sales_quotations
+  has_many :purchase_quotations
   has_many :representatives, inverse_of: :customer
   accepts_nested_attributes_for :representatives, reject_if: :all_blank, allow_destroy: true
 

--- a/app/views/customers/show.html.erb
+++ b/app/views/customers/show.html.erb
@@ -1,38 +1,46 @@
-<div class = page-wrapper>
-<div class="container mt-5">
-  <div class="row justify-content-center">
-    <div class="col-6">
-      <div class="card mb-3">
-        <div class="card-header bg-primary text-white">
-          会社詳細
+<div class="page-wrapper">
+  <div class="container mt-5">
+    <div class="row justify-content-center">
+      <div class="col-lg-8">
+        <div class="mb-4">
+          <h2 class="text-primary mb-3"><%= @customer.customer_name %></h2>
+          <div class="card">
+            <div class="card-header bg-primary text-white">
+              会社詳細
+            </div>
+            <div class="card-body">
+              <p class="card-text mb-1"><strong>顧客コード: </strong><%= @customer.customer_code %></p>
+              <p class="card-text mb-1"><strong>住 所: </strong><%= @customer.address %></p>
+              <p class="card-text mb-1"><strong>電話番号: </strong><%= @customer.phone_number %></p>
+            </div>
+          </div>
         </div>
-        <div class="card-body">
-          <p class="card-text"><strong>顧客コード: </strong><%= @customer.customer_code %></p>
-          <p class="card-text"><strong>会 社 名: </strong><%= @customer.customer_name %></p>
-          <p class="card-text"><strong>住 所: </strong><%= @customer.address %></p>
-          <p class="card-text"><strong>電話番号: </strong><%= @customer.phone_number %></p>
+
+        <% @customer.representatives.each do |representative| %>
+          <div class="card mb-3 shadow-sm">
+            <div class="card-header bg-secondary text-white">
+              担当者
+            </div>
+            <div class="card-body">
+              <p class="card-text mb-1"><strong>担当部署: </strong><%= representative.department_name %></p>
+              <p class="card-text mb-1"><strong>担当者名: </strong><%= representative.representative_name %></p>
+              <p class="card-text mb-1"><strong>Email: </strong><%= representative.email %></p>
+              <p class="card-text mb-1"><strong>電話番号: </strong><%= representative.phone_number %></p>
+            </div>
+          </div>
+        <% end %>
+
+        <div class="d-flex justify-content-between mt-4">
+          <%= link_to '顧客一覧に戻る', customers_path, class: 'btn btn-outline-primary mr-2' %>
+          <%= link_to '編集', edit_customer_path(@customer), class: 'btn btn-outline-secondary mr-2' %>
+          <%= link_to '担当者を追加', new_customer_representative_path(@customer), class: "btn btn-outline-dark" %>
+        </div>
+
+        <div class="mt-3">
+          <%= link_to '販売見積', new_sales_quotation_path(customer_id: @customer.id), class: 'btn btn-primary mr-2' %>
+          <%= link_to '仕入見積', new_purchase_quotation_path(customer_id: @customer.id), class: 'btn btn-secondary' %>
         </div>
       </div>
-
-      <% @customer.representatives.each do |representative| %>
-        <div class="card mb-3 shadow-sm">
-
-          <div class="card-header bg-primary text-white">
-            担当者
-          </div>
-          <div class="card-body">
-            <p class="card-text"><strong>担当部署: </strong><%= representative.department_name %></p>
-            <p class="card-text"><strong>担当者名: </strong><%= representative.representative_name %></p>
-            <p class="card-text"><strong>Email: </strong><%= representative.email %></p>
-            <p class="card-text"><strong>電話番号: </strong><%= representative.phone_number %></p>
-          </div>
-        </div>
-      <% end %>
-
-      <%= link_to '顧客一覧に戻る', customers_path, class: 'btn btn-primary mr-2' %>
-      <%= link_to '編集', edit_customer_path(@customer), class: 'btn btn-secondary' %>
-      <%= link_to '担当者を追加', new_customer_representative_path(@customer), class: "btn btn-secondary" %>
     </div>
   </div>
-</div>
 </div>

--- a/app/views/purchase_quotations/new.html.erb
+++ b/app/views/purchase_quotations/new.html.erb
@@ -26,7 +26,7 @@
     
           <div data-controller="purchase_quotation">
             <%= form.label :customer_id, "顧客名" %>
-            <%= form.select :customer_id, options_for_select(@customers), { include_blank: '選択してください' }, { class: "form-control select2-customer", data: { action: "change->purchase-quotation#fetchRepresentatives" } } %>
+            <%= form.select :customer_id, options_for_select(@customers, @customer ? @customer.id : nil), { include_blank: '選択してください' }, { class: "form-control select2-customer" } %>
 
             <%= form.label :representative_id, "部署名 - 担当者名" %>
             <%= turbo_frame_tag "representative_options" do %>

--- a/app/views/sales_quotations/new.html.erb
+++ b/app/views/sales_quotations/new.html.erb
@@ -26,7 +26,7 @@
     
           <div data-controller="sales_quotation">
             <%= form.label :customer_id, "顧客名" %>
-            <%= form.select :customer_id, options_for_select(@customers), { include_blank: '選択してください' }, { class: "form-control select2-customer", data: { action: "change->sales-quotation#fetchRepresentatives" } } %>
+            <%= form.select :customer_id, options_for_select(@customers, @customer ? @customer.id : nil), { include_blank: '選択してください' }, { class: "form-control select2-customer" } %>
 
             <%= form.label :representative_id, "部署名 - 担当者名" %>
             <%= turbo_frame_tag "representative_options" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   resources :company_infos, only: [:new, :create, :index, :show, :edit, :update]
   
   resources :customers, only: [:new, :create, :index, :show, :edit, :update] do
+    resources :sales_quotations, only: [:new]
+    resources :purchase_quotations, only: [:new]
     resources :representatives, only: [:new, :create]
     collection do
       get :find


### PR DESCRIPTION
# What

顧客検索した際に詳細ページから見積を出せれば便利だと思ったため実装

# Why

- 顧客詳細ページから"販売見積"”仕入見積”作成ページへのリンクを作成
- 顧客IDを保持し、新規見積作成ページへ遷移。